### PR TITLE
Load Performance

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -5,14 +5,6 @@
     <link rel="icon" href="%sveltekit.assets%/favicon.png" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
 
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;900&family=JetBrains+Mono:ital,wght@0,300;0,400;0,500;0,800;1,700&display=swap"
-      rel="stylesheet"
-    />
-
     <script>
       if (!localStorage.theme) {
         document.documentElement.classList.add('dark')

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -30,8 +30,8 @@
 </svelte:head>
 
 <main>
-  <section class='md:min-h-96 xl:min-h-[500px] p-7 pb-16 md:px-28 lg:px-40  border-y-[#E9E9E9] dark:border-b-white/25 border-b-2 border-dotted dark:bg-white/5 flex flex-col items-start justify-start lg:items-center lg:justify-center bg-[radial-gradient(rgba(255,255,255,0.35),transparent_1px)] [background-size:36px_36px]'>
-    <h1 class='title text-olive-500 lg:text-center font-medium text-2xl md:text-4xl lg:text-[40px] max-w-lg font-mono tracking-tighter [word-spacing:-7px] xl:[word-spacing:-12px] antialiased'>
+  <section class='md:min-h-96 xl:min-h-[500px] p-7 pb-16 md:px-28 lg:px-40 border-y-[#E9E9E9] dark:border-b-white/25 border-b-2 border-dotted dark:bg-white/5 flex flex-col items-start justify-start lg:items-center lg:justify-center bg-[radial-gradient(rgba(255,255,255,0.35),transparent_1px)] [background-size:36px_36px]'>
+    <h1 class='title text-olive-500 lg:text-center font-medium text-2xl md:text-4xl lg:text-[40px] max-w-2xl font-mono tracking-tighter [word-spacing:-7px] xl:[word-spacing:-15px] antialiased'>
       I love to design and build experiences for the web.
     </h1>
 

--- a/src/routes/blog/post/[slug]/+page.svelte
+++ b/src/routes/blog/post/[slug]/+page.svelte
@@ -24,8 +24,8 @@
   />
 </svelte:head>
 
-<div class='w-full p-7 md:py-28 md:px-28 lg:px-40 border-b-[#E9E9E9] dark:border-b-white/25 border-b-2 border-dotted dark:bg-white/5'>
-  <h1 class='text-center text-olive-500 font-medium text-2xl md:text-4xl lg:text-[40px] font-mono tracking-tighter [word-spacing:-7px] xl:[word-spacing:-12px] antialiased'>
+<div class='w-full p-7 md:py-28 md:px-28 lg:px-40 border-b-[#E9E9E9] dark:border-b-white/25 border-b-2 border-dotted dark:bg-white/5 flex flex-col items-center'>
+  <h1 class='text-center text-olive-500 font-medium text-3xl md:text-4xl lg:text-[40px] max-w-xl font-mono tracking-tighter [word-spacing:-7px] xl:[word-spacing:-15px] antialiased'>
     {title}
   </h1>
 
@@ -45,7 +45,7 @@
     {@html marked(body)}
   </main>
 
-  <div class='max-w-xl mx-auto flex justify-center mt-16 border-t-2 border-t-black/25 dark:border-t-white/25 border-dotted pt-5'>
+  <div class='w-full max-w-xl mt-16 border-t-2 border-t-black/25 dark:border-t-white/25 border-dotted pt-5'>
     <button
       class='flex items-center justify-center text-center mx-auto text-xs focus:outline-dotted dark:focus:outline-white/50 hover:opacity-30'
       on:click={scrollToTop}>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -5,7 +5,7 @@ const config = {
 
   theme: {
     fontFamily: {
-      mono: ['JetBrains Mono', 'monospace']
+      mono: ['Courier', 'monospace']
     },
     extend: {
       colors: {


### PR DESCRIPTION
This PR contains performance tweaks. It removes the Jet Brains Mono font that I was using for my headings, which was hosted on Google Fonts. Removing this gave me perfect scores across the board on page speed insights! 🎉 🎊

I decided to use Courier monospace since it's pretty common, but will. default to the mono font the OS will provide. The details of these mono fonts are so small that nobody will notice them, and not worth it to justify the performance impact.

Along with this change came some css tweaks because of the font change to ensure the h1 styling remained more or less the same as the previous font.

Here's mobile **BEFORE** the change:
<img width="993" alt="Screenshot 2023-10-04 at 10 08 23 AM" src="https://github.com/joelriveradev/joelrivera.dev/assets/10171624/c2553d58-0837-4e4c-8ae1-9cf1f93a5d4c">

Here's mobile **AFTER** the change:
<img width="997" alt="Screenshot 2023-10-04 at 10 01 33 AM" src="https://github.com/joelriveradev/joelrivera.dev/assets/10171624/0fb9b863-f5ff-4443-b95a-b4b63511e076">

Here's desktop **BEFORE** the change:
<img width="993" alt="Screenshot 2023-10-04 at 10 10 03 AM" src="https://github.com/joelriveradev/joelrivera.dev/assets/10171624/8eb1c62e-72fb-4e89-8653-9195bd48fd05">

Here's desktop **AFTER** the change:
<img width="982" alt="Screenshot 2023-10-04 at 10 01 17 AM" src="https://github.com/joelriveradev/joelrivera.dev/assets/10171624/2a9e9192-2fac-4225-8992-8d05298b44b0">

The results for desktop are negligible, but for mobile, it's quite an improvement. Mobile is more critical for performance than desktop is, so this change was definitely worth it. We're taking about a 1.5 sec improvement in load time performance! Anyways, so long Jet Brains Mono.
